### PR TITLE
Add optionally custom trufflehog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Available scanner types:
 | `"trufflehog"` | Secrets detection in git history |
 | `"confusion-hunter"` | Dependency confusion vulnerability detection |
 
+#### Custom TruffleHog Detectors
+
+You can extend TruffleHog with custom secret detectors by placing a configuration file at `gsast/configs/trufflehog_config.yaml`. When this file is present, it is automatically passed to TruffleHog via `--config` and the custom detectors run alongside the built-in ones.
+
+See the [TruffleHog custom detectors documentation](https://trufflesecurity.com/blog/trufflehog-custom-detectors) for the YAML format reference.
 
 ### How Scans Work
 

--- a/gsast/sastlib/trufflehog_api.py
+++ b/gsast/sastlib/trufflehog_api.py
@@ -47,6 +47,13 @@ def scan_for_secrets(trufflehog, scan_cwd: Path, project_sources_dir: Path) -> O
         '--no-update',
     ]
 
+    custom_config_path = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
+    if custom_config_path.exists():
+        trufflehog_args.extend(['--config', str(custom_config_path)])
+        log.debug(f'Using custom TruffleHog config: {custom_config_path}')
+    else:
+        log.debug('No custom TruffleHog config found, using built-in detectors only')
+
     # Inherit SSL and proxy settings from the container environment (Helm chart sets these).
     # Do not override here so we can support both internal GitLab CA and corporate proxy CA bundles.
     # Note: TruffleHog may exit with code 1 for various reasons (no findings, not a git repo, etc.)

--- a/gsast/sastlib/trufflehog_api.py
+++ b/gsast/sastlib/trufflehog_api.py
@@ -10,6 +10,8 @@ from utils.safe_logging import log
 from sastlib.results_splitter import trufflehog_to_sarif_and_split_by_source
 from sastlib.scanner_utils import run_command
 
+CUSTOM_CONFIG_PATH = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
+
 
 def run_scan(project_sources_dir: Path, scan_cwd: Path) -> Optional[Dict[str, Path]]:
     log.info('Running TruffleHog scan')
@@ -47,10 +49,9 @@ def scan_for_secrets(trufflehog, scan_cwd: Path, project_sources_dir: Path) -> O
         '--no-update',
     ]
 
-    custom_config_path = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
-    if custom_config_path.exists():
-        trufflehog_args.extend(['--config', str(custom_config_path)])
-        log.debug(f'Using custom TruffleHog config: {custom_config_path}')
+    if CUSTOM_CONFIG_PATH.exists():
+        trufflehog_args.extend(['--config', str(CUSTOM_CONFIG_PATH)])
+        log.debug(f'Using custom TruffleHog config: {CUSTOM_CONFIG_PATH}')
     else:
         log.debug('No custom TruffleHog config found, using built-in detectors only')
 


### PR DESCRIPTION
The trufflehog initiator now looks into `configs` dir for a file `trufflehog_config.yaml`. 

If the file is present, it passes it to the trufflehog as a detector configuration file.

Added mention to the README.md as well