### PR TITLE
Fix Trufflehog SARIF Results Bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Available scanner types:
 | `"trufflehog"` | Secrets detection in git history |
 | `"confusion-hunter"` | Dependency confusion vulnerability detection |
 
+#### Custom TruffleHog Detectors
+
+You can extend TruffleHog with custom secret detectors by placing a configuration file at `gsast/configs/trufflehog_config.yaml`. When this file is present, it is automatically passed to TruffleHog via `--config` and the custom detectors run alongside the built-in ones.
+
+See the [TruffleHog custom detectors documentation](https://trufflesecurity.com/blog/trufflehog-custom-detectors) for the YAML format reference.
 
 ### How Scans Work
 

--- a/gsast/sastlib/results_splitter.py
+++ b/gsast/sastlib/results_splitter.py
@@ -49,13 +49,13 @@ def split_sarif_by_rules(sarif_path: Path) -> Optional[Dict[str, Path]]:
 def convert_trufflehog_to_sarif(json_path: Path) -> Path:
     """
     Reads line-delimited Trufflehog JSON results and converts them into
-    a single SARIF file. One SARIF 'rule' is generated
-    per finding so we can store:
-      - A concise 'message' in result.message
-      - The longer text (commit link, impact, mitigation, etc.) in rule.shortDescription
+    a single SARIF file. One SARIF 'rule' is generated per unique detector type
+    (keyed by source_name + detector_name + detector_description):
+      - The rule's shortDescription contains impact, mitigation, and detector description
+      - Each finding becomes a separate 'result' referencing the shared rule
 
     The final SARIF structure:
-      - runs[0].tool.driver.rules[...] -> Each rule has an 'id' and 'shortDescription.text'
+      - runs[0].tool.driver.rules[...] -> One rule per unique detector type
       - runs[0].results[...] -> Each result references the ruleId, and has a short 'message.text'.
 
     Returns:
@@ -97,8 +97,8 @@ def convert_trufflehog_to_sarif(json_path: Path) -> Path:
 
     driver_rules = sarif_template["runs"][0]["tool"]["driver"]["rules"]
     results = []
-    rule_ids_mapper = dict() # hash to count
-    detectors_count_mapper = defaultdict(int) # detector to count
+    seen_detectors = {}  # hash_key -> rule_id
+    rule_counter = 0
 
     with open(json_path, 'r', encoding='utf-8') as f:
         for i, line in enumerate(f):
@@ -132,33 +132,33 @@ def convert_trufflehog_to_sarif(json_path: Path) -> Path:
 
             short_msg = f"Hard Coded {detector_name} Secret - {file_path}"
 
-            long_text_parts = []
-            if commit_link:
-                long_text_parts.append(f"**Commit:** {commit_link}")
-            long_text_parts.append(f"**Impact:** {impact_text}")
-            long_text_parts.append(f"**Mitigation:** {mitigation_text}")
-            if detector_desc:
-                long_text_parts.append(f"**Description:** {detector_desc}")
-
-            long_text = "\n\n".join(long_text_parts)
-
             rule_id_hash = hashlib.sha256()
-            rule_id_hash.update((detector_name).encode())
-            rule_id_hash.update((detector_desc).encode())
-            if rule_id_hash.hexdigest() in rule_ids_mapper:                
-                rule_id_seq_count = detectors_count_mapper[rule_id_hash.hexdigest()]
+            rule_id_hash.update(source_name.encode())
+            rule_id_hash.update(detector_name.encode())
+            rule_id_hash.update(detector_desc.encode())
+            hash_key = rule_id_hash.hexdigest()
+
+            if hash_key in seen_detectors:
+                rule_id = seen_detectors[hash_key]
             else:
-                detectors_count_mapper[detector_name] += 1
-                rule_id_seq_count = detectors_count_mapper[detector_name]
-                rule_ids_mapper[rule_id_hash.hexdigest()] = rule_id_seq_count
-            rule_id = f"{source_name} {rule_id_seq_count+1}"
-            driver_rules.append({
-                "id": rule_id,
-                "name": f"Trufflehog {detector_name}",
-                "shortDescription": {
-                    "text": long_text
-                },
-            })
+                rule_counter += 1
+                rule_id = f"{source_name} {rule_counter}"
+                seen_detectors[hash_key] = rule_id
+
+                long_text_parts = []
+                long_text_parts.append(f"**Impact:** {impact_text}")
+                long_text_parts.append(f"**Mitigation:** {mitigation_text}")
+                if detector_desc:
+                    long_text_parts.append(f"**Description:** {detector_desc}")
+                long_text = "\n\n".join(long_text_parts)
+
+                driver_rules.append({
+                    "id": rule_id,
+                    "name": f"Trufflehog {detector_name}",
+                    "shortDescription": {
+                        "text": long_text
+                    },
+                })
 
             sarif_result = {
                 "ruleId": rule_id,
@@ -184,6 +184,7 @@ def convert_trufflehog_to_sarif(json_path: Path) -> Path:
                 ],
                 "properties": {
                     "commit": commit_id,
+                    "commit_link": commit_link,
                     "repository": repository,
                     "verified": verified,
                     "raw_secret": raw_secret

--- a/gsast/sastlib/results_storage.py
+++ b/gsast/sastlib/results_storage.py
@@ -28,14 +28,29 @@ def store_scan_results(scans_redis: Redis, scan_id: str, project_url: str, scann
         # Create the key for storing results for this project in this scan
         results_key = f"{scan_id}:results:{project_url}"
         
-        # Read and store each SARIF file
+        # Read and merge all split SARIF files into one consolidated result
         stored_results = {}
         for _, sarif_path in results_paths.items():
             try:
                 with open(sarif_path, 'r') as f:
                     sarif_content = json.load(f)
-                    stored_results[scanner_type] = sarif_content
-                    log.debug(f"Stored {scanner_type} results")
+
+                    if scanner_type not in stored_results:
+                        stored_results[scanner_type] = sarif_content
+                    else:
+                        existing = stored_results[scanner_type]
+                        existing['runs'][0]['results'].extend(
+                            sarif_content['runs'][0].get('results', [])
+                        )
+                        existing_rule_ids = {
+                            r['id'] for r in existing['runs'][0]['tool']['driver'].get('rules', [])
+                        }
+                        for rule in sarif_content['runs'][0]['tool']['driver'].get('rules', []):
+                            if rule['id'] not in existing_rule_ids:
+                                existing['runs'][0]['tool']['driver']['rules'].append(rule)
+                                existing_rule_ids.add(rule['id'])
+
+                    log.debug(f"Stored {scanner_type} results from {sarif_path}")
             except Exception as e:
                 log.error(f"Failed to read SARIF file {sarif_path}: {e}")
                 return False

--- a/gsast/sastlib/scanner_utils.py
+++ b/gsast/sastlib/scanner_utils.py
@@ -42,15 +42,18 @@ def has_findings_trufflehog(json_results_path: Path) -> bool:
     with open(json_results_path, 'r') as json_results_file:
         json_result_lines = json_results_file.readlines()
 
-    try:
-        json_results = [json.loads(line) for line in json_result_lines]
-    except json.JSONDecodeError:
-        log.error(f'Invalid JSON file: {json_results_path} with content: {json_result_lines}')
-        return False
+    json_results = []
+    for line in json_result_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            json_results.append(json.loads(line))
+        except json.JSONDecodeError:
+            log.warning(f'Skipping invalid JSON line in {json_results_path}')
+            continue
 
-    if len(json_results):
-        return True
-    return False
+    return len(json_results) > 0
 
 
 def has_findings(results_path: Path, scan_type: str) -> bool:

--- a/gsast/sastlib/trufflehog_api.py
+++ b/gsast/sastlib/trufflehog_api.py
@@ -47,6 +47,13 @@ def scan_for_secrets(trufflehog, scan_cwd: Path, project_sources_dir: Path) -> O
         '--no-update',
     ]
 
+    custom_config_path = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
+    if custom_config_path.exists():
+        trufflehog_args.extend(['--config', str(custom_config_path)])
+        log.debug(f'Using custom TruffleHog config: {custom_config_path}')
+    else:
+        log.debug('No custom TruffleHog config found, using built-in detectors only')
+
     # Inherit SSL and proxy settings from the container environment (Helm chart sets these).
     # Do not override here so we can support both internal GitLab CA and corporate proxy CA bundles.
     # Note: TruffleHog may exit with code 1 for various reasons (no findings, not a git repo, etc.)

--- a/gsast/sastlib/trufflehog_api.py
+++ b/gsast/sastlib/trufflehog_api.py
@@ -10,6 +10,8 @@ from utils.safe_logging import log
 from sastlib.results_splitter import trufflehog_to_sarif_and_split_by_source
 from sastlib.scanner_utils import run_command
 
+CUSTOM_CONFIG_PATH = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
+
 
 def run_scan(project_sources_dir: Path, scan_cwd: Path) -> Optional[Dict[str, Path]]:
     log.info('Running TruffleHog scan')
@@ -47,10 +49,9 @@ def scan_for_secrets(trufflehog, scan_cwd: Path, project_sources_dir: Path) -> O
         '--no-update',
     ]
 
-    custom_config_path = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
-    if custom_config_path.exists():
-        trufflehog_args.extend(['--config', str(custom_config_path)])
-        log.debug(f'Using custom TruffleHog config: {custom_config_path}')
+    if CUSTOM_CONFIG_PATH.exists():
+        trufflehog_args.extend(['--config', str(CUSTOM_CONFIG_PATH)])
+        log.debug(f'Using custom TruffleHog config: {CUSTOM_CONFIG_PATH}')
     else:
         log.debug('No custom TruffleHog config found, using built-in detectors only')
 

--- a/gsast/sastlib/trufflehog_api.py
+++ b/gsast/sastlib/trufflehog_api.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import time
 import subprocess
@@ -11,6 +12,7 @@ from sastlib.results_splitter import trufflehog_to_sarif_and_split_by_source
 from sastlib.scanner_utils import run_command
 
 CUSTOM_CONFIG_PATH = Path(__file__).resolve().parent.parent / 'configs' / 'trufflehog_config.yaml'
+ONLY_VERIFIED = os.getenv('TRUFFLEHOG_ONLY_VERIFIED', 'true').lower() == 'true'
 
 
 def run_scan(project_sources_dir: Path, scan_cwd: Path) -> Optional[Dict[str, Path]]:
@@ -42,12 +44,17 @@ def scan_for_secrets(trufflehog, scan_cwd: Path, project_sources_dir: Path) -> O
         trufflehog,
         'git',
         f'file://{project_sources_dir}',
-        '--only-verified',
         '-j',
         '--verifier',
         f'github={GITHUB_URL}' if (project_sources_dir / '.github').exists() else f'gitlab={GITLAB_URL}',
         '--no-update',
     ]
+
+    if ONLY_VERIFIED:
+        trufflehog_args.append('--only-verified')
+        log.debug('TruffleHog will report only verified secrets')
+    else:
+        log.debug('TruffleHog will report all secrets (verified and unverified)')
 
     if CUSTOM_CONFIG_PATH.exists():
         trufflehog_args.extend(['--config', str(CUSTOM_CONFIG_PATH)])

--- a/gsast/tests/test_trufflehog_sarif.py
+++ b/gsast/tests/test_trufflehog_sarif.py
@@ -65,10 +65,61 @@ def test_trufflehog_to_sarif_includes_schema_field():
         assert "artifactLocation" in location["physicalLocation"]
         assert "uri" in location["physicalLocation"]["artifactLocation"]
         
-        print("✅ All TruffleHog SARIF conversion tests passed!")
+        print("Passed: TruffleHog SARIF conversion test")
         
     finally:
         # Cleanup
+        json_path.unlink()
+        if sarif_path.exists():
+            sarif_path.unlink()
+
+
+def test_trufflehog_rule_deduplication():
+    """Test that multiple findings of the same detector type share one rule, 
+    and different detector types get distinct rule IDs."""
+    
+    sample_output = (
+        '{"SourceName":"trufflehog - git","DetectorName":"PrivateKey","DetectorDescription":"PK desc","Verified":false,"Raw":"secret1","SourceMetadata":{"Data":{"Git":{"commit":"aaa","file":"file1.pem","line":1,"repository":"https://gitlab.example.com/project/repo.git"}}}}\n'
+        '{"SourceName":"trufflehog - git","DetectorName":"PrivateKey","DetectorDescription":"PK desc","Verified":false,"Raw":"secret2","SourceMetadata":{"Data":{"Git":{"commit":"bbb","file":"file2.pem","line":5,"repository":"https://gitlab.example.com/project/repo.git"}}}}\n'
+        '{"SourceName":"trufflehog - git","DetectorName":"PrivateKey","DetectorDescription":"PK desc","Verified":false,"Raw":"secret3","SourceMetadata":{"Data":{"Git":{"commit":"ccc","file":"file3.pem","line":10,"repository":"https://gitlab.example.com/project/repo.git"}}}}\n'
+        '{"SourceName":"trufflehog - git","DetectorName":"URI","DetectorDescription":"URI desc","Verified":false,"Raw":"http://user:pass@host","SourceMetadata":{"Data":{"Git":{"commit":"ddd","file":"config.js","line":20,"repository":"https://gitlab.example.com/project/repo.git"}}}}\n'
+        '{"SourceName":"trufflehog - git","DetectorName":"URI","DetectorDescription":"URI desc","Verified":false,"Raw":"http://admin:admin@host","SourceMetadata":{"Data":{"Git":{"commit":"eee","file":"env.js","line":30,"repository":"https://gitlab.example.com/project/repo.git"}}}}\n'
+    )
+    
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+        f.write(sample_output)
+        json_path = Path(f.name)
+    
+    try:
+        sarif_path = convert_trufflehog_to_sarif(json_path)
+        
+        with open(sarif_path, 'r', encoding='utf-8') as f:
+            sarif_data = json.load(f)
+        
+        rules = sarif_data["runs"][0]["tool"]["driver"]["rules"]
+        results = sarif_data["runs"][0]["results"]
+        
+        assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+        assert len(rules) == 2, f"Expected 2 rules (PrivateKey + URI), got {len(rules)}"
+        
+        rule_ids = [r["id"] for r in rules]
+        assert len(set(rule_ids)) == 2, f"Rule IDs should be unique, got: {rule_ids}"
+        
+        pk_rule_id = rules[0]["id"]
+        uri_rule_id = rules[1]["id"]
+        assert pk_rule_id != uri_rule_id, "PrivateKey and URI must have different rule IDs"
+        
+        pk_results = [r for r in results if r["ruleId"] == pk_rule_id]
+        uri_results = [r for r in results if r["ruleId"] == uri_rule_id]
+        assert len(pk_results) == 3, f"Expected 3 PrivateKey results, got {len(pk_results)}"
+        assert len(uri_results) == 2, f"Expected 2 URI results, got {len(uri_results)}"
+        
+        for r in results:
+            assert "commit_link" in r["properties"], "Result should have commit_link in properties"
+        
+        print("Passed: Rule deduplication test")
+        
+    finally:
         json_path.unlink()
         if sarif_path.exists():
             sarif_path.unlink()
@@ -111,4 +162,5 @@ def test_trufflehog_empty_output():
 if __name__ == "__main__":
     test_trufflehog_to_sarif_includes_schema_field()
     test_trufflehog_empty_output()
+    test_trufflehog_rule_deduplication()
 


### PR DESCRIPTION
A bug was found when running the trufflehog inside GSAST without parameter `--only-verified`. After further investigation, several more bugs were found, namely:

- **Rule ID mapper key mismatch** - The `detectors_count_mapper` in `convert_trufflehog_to_sarif()` was stored using `detector_name` as key but looked up using `rule_id_hash.hexdigest()`. Since `defaultdict(int)` returns `0` for any unseen key, almost all findings ended up with the same rule ID "trufflehog - git 1", causing different detector types to collide and get mixed together.

- **Duplicate rules created for every finding** - A new rule was appended to `driver_rules` for every single finding, instead of once per unique detector type. With `--only-verified` off this meant thousands of duplicate rule entries in the SARIF output.

- **Results storage overwrite** - In `store_scan_results()`, the loop over split SARIF files always used the same key `stored_results[scanner_type]`, so each iteration overwrote the previous one. Only the last split file was kept, the rest were silently lost.

- **Empty line handling in `has_findings_trufflehog()`** - The function didn't strip empty lines before calling `json.loads()`, so a trailing newline in the TruffleHog output caused a `JSONDecodeError` and the function returned False even when findings existed.

All these bugs should be handled by the suggested changes. I tested ONLY the json -> SARIF "pipeline" of GSAST, did not try it as a whole.